### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,6 @@ jobs:
       release-tag: ${{ steps.next-version.outputs.release-tag }}
       release-version: ${{ steps.next-version.outputs.release-version }}
 
-
   docker:
     uses: ./.github/workflows/docker-build-and-push-workflow.yml
     needs: analyze-commits
@@ -58,6 +57,30 @@ jobs:
         ${{ (startsWith(github.ref, 'refs/tags/') ||
           github.ref == 'refs/heads/main') &&
           github.event_name == 'push' }}
+
+  release: 
+    runs-on: ubuntu-latest
+    needs: publish-docker
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - 
+      name: "🔧 setup node"
+      uses: actions/setup-node@v2.1.5
+      with:
+        node-version: 18.x
+    - 
+      name: Install dependencies
+      run: yarn global add semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/exec @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
+    - 
+      name: Semantic Release
+      run: "semantic-release"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-docker:
     runs-on: ubuntu-latest
@@ -94,27 +117,3 @@ jobs:
     -
       name: Push Docker image
       run: docker push ${{ vars.DOCKER_IMAGE_REPOSITORY }} --all-tags
-
-  release: 
-    runs-on: ubuntu-latest
-    needs: publish-docker
-    steps:
-    - 
-      name: Checkout
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - 
-      name: "🔧 setup node"
-      uses: actions/setup-node@v2.1.5
-      with:
-        node-version: 18.x
-    - 
-      name: Install dependencies
-      run: yarn global add semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/exec @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
-    - 
-      name: Semantic Release
-      run: "semantic-release"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - main
-      - master
   push:
     branches:
       - main
-      - master
 
 jobs:
   analyze-commits:
@@ -53,14 +51,12 @@ jobs:
       version: ${{ needs.analyze-commits.outputs.release-version }}
       publish: >- 
         ${{ (startsWith(github.ref, 'refs/tags/') ||
-            github.ref == 'refs/heads/main' ||
-            github.ref == 'refs/heads/master') &&
+            github.ref == 'refs/heads/main') &&
             github.event_name == 'push' }}
       docker-image-repo: ${{ vars.DOCKER_IMAGE_REPOSITORY }}
       upload-sarif-to-security: >- 
         ${{ (startsWith(github.ref, 'refs/tags/') ||
-          github.ref == 'refs/heads/main' ||
-          github.ref == 'refs/heads/master') &&
+          github.ref == 'refs/heads/main') &&
           github.event_name == 'push' }}
 
   publish-docker:
@@ -69,8 +65,7 @@ jobs:
     - docker
     if: >- 
       ${{ (startsWith(github.ref, 'refs/tags/') ||
-          github.ref == 'refs/heads/main' ||
-          github.ref == 'refs/heads/master') &&
+          github.ref == 'refs/heads/main') &&
           github.event_name == 'push' }}
     steps:
     - 

--- a/.github/workflows/docker-build-and-push-workflow.yml
+++ b/.github/workflows/docker-build-and-push-workflow.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
         required: false
         description: Add latest flavor
-        default: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+        default: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       upload-sarif-to-security:
         type: boolean
         required: false


### PR DESCRIPTION
* Remove master from GH actions, this is a non-existing branch. Someone could make one and push to it, we don't want to run the actions here.
* Fix the order of the release and publish to Docker. Last time the release failed, but a docker image with that version was pushed. This results in a version that doesn't exist yet. And to make it worse, the Docker image will be overwritten the next time that the release _is_ made, which can break things on the user-side.